### PR TITLE
Improving code maintainability and adding sqrt method to improve compatibility with numpy

### DIFF
--- a/cfractions/__init__.py
+++ b/cfractions/__init__.py
@@ -3,6 +3,7 @@
 __version__ = '1.4.0'
 
 import numbers as _numbers
+import fractions as _fractions
 
 try:
     from _cfractions import Fraction as _Fraction
@@ -21,8 +22,8 @@ _Number = _TypeVar('_Number',
 
 
 class Fraction(_Fraction):
-    def sqrt(self) -> 'Fraction':
-        return Fraction((self.numerator / self.denominator)**.5)
+    def sqrt(self) -> _Union[float, complex]:
+        return (self.numerator / self.denominator)**.5
 
     def limit_denominator(self, max_denominator: int = 10 ** 6
                           ) -> 'Fraction':
@@ -271,9 +272,12 @@ class Fraction(_Fraction):
 
     def __round__(self, precision: _Optional[int] = None
                   ) -> _Union[int, 'Fraction']:
-        result = super().__round__(precision)
+        if isinstance(precision, int):
+            result = super().__round__(precision)
+        else:
+            result = _fractions.Fraction(self).__round__(precision)
         return (Fraction(result.numerator, result.denominator)
-                if isinstance(result, _Fraction)
+                if isinstance(result, _Fraction) or isinstance(result, _fractions.Fraction)
                 else result)
 
     def __rpow__(self,


### PR DESCRIPTION
I refactored **\__init__.py** so that the Fraction skeleton would stay the same in case of ImportError to:
- improve code maintainability
- make it easier for contributors to improve the code

2 test cases were non working in case of ImportError: now only one test case fails: **test_reference_counter** at **tests/fraction_tests/test_pos.py**.

Fixed return in **\__new__** method when denominator parameter is missing.

**\__round__** method didn't work when importing _Fraction from **_cfractions** in case of **precision** argument = **None**, now it does.

I added **sqrt**method to improve compatibility with package numpy (functions like **numpy.sqrt()** and **nupy.norm()** now work properly on fractions and array of fractions respectively),

I really appreciate the job the job that you have done and I made sure that my code was minimal to make it easy to review it.