### PR TITLE
Correct typing for __(r)truediv__ with ints

### DIFF
--- a/cfractions/__init__.pyi
+++ b/cfractions/__init__.pyi
@@ -239,7 +239,7 @@ class Fraction(_numbers.Rational):
         ...
 
     @_overload
-    def __rtruediv__(self, other: _numbers.Rational) -> 'Fraction':
+    def __rtruediv__(self, other: _Union[int, _numbers.Rational]) -> 'Fraction':
         ...
 
     @_overload
@@ -255,7 +255,7 @@ class Fraction(_numbers.Rational):
         ...
 
     @_overload
-    def __truediv__(self, other: _numbers.Rational) -> 'Fraction':
+    def __truediv__(self, other: _Union[int, _numbers.Rational]) -> 'Fraction':
         ...
 
     @_overload


### PR DESCRIPTION
When dividing with an `int`, a Fraction is returned.

Because the method parameters are contravariant, an `int` is accepted in the `float` overload in `__init__.pyi`. So for type checkers, `Fraction(1)/1` returns a float while in reality it returns a Fraction.

This is in line with the builtin fractions, where `int | Fraction` is used instead.